### PR TITLE
Add extended json result format

### DIFF
--- a/src/org/opensextant/service/processing/DocumentProcessorPool.java
+++ b/src/org/opensextant/service/processing/DocumentProcessorPool.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
+import org.opensextant.placedata.PlaceCandidate;
 import org.opensextant.service.OpenSextantExtractorResource;
 import org.opensextant.tagger.Document;
 import org.opensextant.tagger.Match;
@@ -242,6 +243,9 @@ public class DocumentProcessorPool {
 			if ("PLACE".equalsIgnoreCase(type)) {
 				tmpAnno.getFeatures().put("place", fm.get("bestPlace"));
 				tmpAnno.getFeatures().put("hierarchy", fm.get("hierarchy"));
+
+				PlaceCandidate pc = (PlaceCandidate) fm.get("placeCandidate");
+				tmpAnno.getFeatures().put("candidates", pc.getPlaces());
 			} else {
 				for (Entry<Object, Object> e : fm.entrySet()) {
 					String k = (String) e.getKey();


### PR DESCRIPTION
The goal of this PR is to make each `placeCandidate`'s list of `Place`s available through the extractor interface. 

Initially we thought the `Place` candidates would already be available to the `convertResult` method. However, I found that the list is trimmed before it reaches `convertResult`. 

The first change made here is to pass the list of `Place` candidates to the `convertResult` method by adding them to the `Document` in the `gateDocToDocument` method.

The second change is made because some of the formats returned by `convertResult` are created by giving the `Document` directly to a third-party's representation constructor. The values added to the `Document` have to be removed in order to preserve the existing result formats. 

The design for the second change could be described as "Use the extended document, remove the 'extended' stuff, use the regular document". It breaks the previous pattern where the document was used as needed only within each `if` statement. I made this change so that the original function could be left un-altered. Alternatively I could put the `Document` altering code into a private function and call it as needed.